### PR TITLE
Feature/formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,8 @@ function convertSchema(schema, options) {
 	}
 
 	validateType(schema.type);
-	schema = convertTypes(schema, options);
+	schema = convertTypes(schema);
+	schema = convertFormat(schema, options);
 
 	if (typeof schema['x-patternProperties'] === 'object'
 			&& options.supportPatternProperties) {
@@ -135,27 +136,93 @@ function validateType(type) {
 	}
 }
 
-function convertTypes(schema, options) {
-	var toDateTime = options.dateToDateTime;
-
-	if (schema.type === undefined) {
-		return schema;
-	}
-
-	if (schema.type == 'string' && schema.format == 'date' && toDateTime === true) {
-		schema.format = 'date-time';
-	}
-
-	if (! schema.format) {
-		delete schema.format;
-	}
-
-	if (schema.nullable === true) {
+function convertTypes(schema) {
+	if (schema.type !== undefined && schema.nullable === true) {
 		schema.type = [schema.type, 'null'];
 	}
 
 	return schema;
 }
+
+function convertFormat(schema, options) {
+	var format = schema.format;
+
+	if (format === undefined || FORMATS.indexOf(format) !== -1) {
+		return schema;
+	}
+
+	var converter = formatConverters[format];
+
+	if (converter === undefined) { return schema; }
+
+	return converter(schema, options);
+}
+
+// Valid JSON schema v4 formats
+var FORMATS = ['date-time', 'email', 'hostname', 'ipv4', 'ipv6', 'uri', 'uri-reference'];
+
+function convertFormatInt32 (schema) {
+	schema.minimum = MIN_INT_32;
+	schema.maximum = MAX_INT_32;
+	return schema;
+}
+
+var MIN_INT_32 = 0 - Math.pow(2, 31);
+var MAX_INT_32 = Math.pow(2, 31) - 1;
+
+function convertFormatInt64 (schema) {
+	schema.minimum = MIN_INT_64;
+	schema.maximum = MAX_INT_64;
+	return schema;
+}
+
+var MIN_INT_64 = 0 - Math.pow(2, 63);
+var MAX_INT_64 = Math.pow(2, 63) - 1;
+
+function convertFormatFloat (schema) {
+	schema.minimum = MIN_FLOAT;
+	schema.maximum = MAX_FLOAT;
+	return schema;
+}
+
+var MIN_FLOAT = 0 - Math.pow(2, 128);
+var MAX_FLOAT = Math.pow(2, 128) - 1;
+
+function convertFormatDouble (schema) {
+	schema.minimum = MIN_DOUBLE;
+	schema.maximum = MAX_DOUBLE;
+	return schema;
+}
+
+var MIN_DOUBLE = 0 - Number.MAX_VALUE;
+var MAX_DOUBLE = Number.MAX_VALUE;
+
+function convertFormatDate (schema, options) {
+	if (options.dateToDateTime === true) {
+		schema.format = 'date-time';
+	}
+
+	return schema;
+}
+
+function convertFormatByte (schema) {
+	schema.pattern = BYTE_PATTERN;
+	return schema;
+}
+
+// Matches base64 (RFC 4648)
+// Matches `standard` base64 not `base64url`. The specification does not
+// exclude it but current ongoing OpenAPI plans will distinguish btoh.
+var BYTE_PATTERN = '^[\\w\\d+\\/=]*$';
+
+var formatConverters = {
+	int32: convertFormatInt32,
+	int64: convertFormatInt64,
+	float: convertFormatFloat,
+	double: convertFormatDouble,
+	date: convertFormatDate,
+	byte: convertFormatByte
+};
 
 function convertPatternProperties(schema, handler) {
 	schema.patternProperties = schema['x-patternProperties'];

--- a/test/combination_keywords.test.js
+++ b/test/combination_keywords.test.js
@@ -17,16 +17,14 @@ test('iterates allOfs', function(assert) {
 				required: ['foo'],
 				properties: {
 					foo: {
-						type: 'integer',
-						format: 'int64'
+						type: 'integer'
 					}
 				}
 			},
 			{
 				allOf: [
 					{
-						type: 'number',
-						format: 'double'
+						type: 'number'
 					}
 				]
 			}
@@ -43,16 +41,14 @@ test('iterates allOfs', function(assert) {
 				required: ['foo'],
 				properties: {
 					foo: {
-						type: 'integer',
-						format: 'int64'
+						type: 'integer'
 					}
 				}
 			},
 			{
 				allOf: [
 					{
-						type: 'number',
-						format: 'double'
+						type: 'number'
 					}
 				]
 			}
@@ -207,7 +203,6 @@ test('converts types in not', function(assert) {
 		properties: {
 			not: {
 				type: 'string',
-				format: 'password',
 				minLength: 8
 			}
 		}
@@ -221,7 +216,6 @@ test('converts types in not', function(assert) {
 		properties: {
 			not: {
 				type: 'string',
-				format: 'password',
 				minLength: 8
 			}
 		}
@@ -241,7 +235,6 @@ test('converts types in not', function(assert) {
 	schema = {
 		not: {
 			type: 'string',
-			format: 'password',
 			minLength: 8
 		}
 	};
@@ -252,7 +245,6 @@ test('converts types in not', function(assert) {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		not: {
 			type: 'string',
-			format: 'password',
 			minLength: 8
 		}
 	};

--- a/test/items.test.js
+++ b/test/items.test.js
@@ -14,7 +14,6 @@ test('items', function(assert) {
 		type: 'array',
 		items: {
 			type: 'string',
-			format: 'date-time',
 			example: '2017-01-01T12:34:56Z'
 		}
 	};
@@ -25,8 +24,7 @@ test('items', function(assert) {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'array',
 		items: {
-			type: 'string',
-			format: 'date-time'
+			type: 'string'
 		}
 	};
 

--- a/test/numeric_types.test.js
+++ b/test/numeric_types.test.js
@@ -2,63 +2,65 @@ var test = require('tape')
 	, convert = require('../')
 ;
 
-test('handles integer types', function(assert) {
+test('handles int32 format', function(assert) {
 	var schema
 		, result
 		, expected
 	;
 
-	assert.plan(2);
+	assert.plan(1);
 
 	schema = {
-		type: 'integer',
-	};
-
-	result = convert(schema);
-
-	expected = {
-		$schema: 'http://json-schema.org/draft-04/schema#',
-		type: 'integer',
-	};
-
-	assert.deepEqual(result, expected, 'integer type untouched');
-
-	schema = {
-		type: 'integer',
-		format: 'int32',
-	};
-
-	result = convert(schema);
-
-	expected = {
-		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'integer',
 		format: 'int32'
 	};
 
-	assert.deepEqual(result, expected, 'integer type and format untouched');
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'integer',
+		format: 'int32',
+		minimum: 0 - Math.pow(2, 31),
+		maximum: Math.pow(2, 31) - 1
+	};
+
+	assert.deepEqual(result, expected, 'int32 converted to minimum|maximum');
 });
 
-test('handles number types', function(assert) {
+test('handles int64 format', function(assert) {
 	var schema
 		, result
 		, expected
 	;
 
-	assert.plan(2);
+	assert.plan(1);
 
 	schema = {
-		type: 'number',
+		type: 'integer',
+		format: 'int64'
 	};
 
 	result = convert(schema);
 
 	expected = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
-		type: 'number',
+		type: 'integer',
+		format: 'int64',
+		minimum: 0 - Math.pow(2, 63),
+		maximum: Math.pow(2, 63) - 1
 	};
 
-	assert.deepEqual(result, expected, 'number type untouched');
+	assert.deepEqual(result, expected, 'int64 converted to minimum|maximum');
+});
+
+test('handles float format', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
 
 	schema = {
 		type: 'number',
@@ -70,8 +72,36 @@ test('handles number types', function(assert) {
 	expected = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'number',
-		format: 'float'
+		format: 'float',
+		minimum: 0 - Math.pow(2, 128),
+		maximum: Math.pow(2, 128) - 1
 	};
 
-	assert.deepEqual(result, expected, 'number type and format untouched');
+	assert.deepEqual(result, expected, 'float converted to minimum|maximum');
+});
+
+test('handles double format', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'number',
+		format: 'double'
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'number',
+		format: 'double',
+		minimum: 0 - Number.MAX_VALUE,
+		maximum: Number.MAX_VALUE
+	};
+
+	assert.deepEqual(result, expected, 'double converted to minimum|maximum');
 });

--- a/test/properties.test.js
+++ b/test/properties.test.js
@@ -134,8 +134,7 @@ test('additionalProperties is an object', function(assert) {
 			type: 'object',
 			properties: {
 				foo: {
-					type: 'string',
-					format: 'date-time'
+					type: 'string'
 				}
 			}
 		}
@@ -155,8 +154,7 @@ test('additionalProperties is an object', function(assert) {
 			type: 'object',
 			properties: {
 				foo: {
-					type: 'string',
-					format: 'date-time'
+					type: 'string'
 				}
 			}
 		}

--- a/test/schemas/schema-1-expected.json
+++ b/test/schemas/schema-1-expected.json
@@ -8,8 +8,7 @@
             "cats": {
               "type": "array",
               "items": {
-                "type": "integer",
-                "format": "int64"
+                "type": "integer"
               }
             }
           }
@@ -20,8 +19,7 @@
             "dogs": {
               "type": "array",
               "items": {
-                "type": "integer",
-                "format": "int64"
+                "type": "integer"
               }
             }
           }
@@ -118,4 +116,3 @@
   ],
   "$schema": "http://json-schema.org/draft-04/schema#"
 }
-

--- a/test/schemas/schema-1.json
+++ b/test/schemas/schema-1.json
@@ -9,7 +9,6 @@
               "type": "array",
               "items": {
                 "type": "integer",
-                "format": "int64",
                 "example": [
                   1
                 ]
@@ -24,7 +23,6 @@
               "type": "array",
               "items": {
                 "type": "integer",
-                "format": "int64",
                 "example": [
                   1
                 ]

--- a/test/schemas/schema-2-invalid-type.json
+++ b/test/schemas/schema-2-invalid-type.json
@@ -9,7 +9,6 @@
               "type": "array",
               "items": {
                 "type": "integer",
-                "format": "int64",
                 "example": [
                   1
                 ]
@@ -24,7 +23,6 @@
               "type": "array",
               "items": {
                 "type": "integer",
-                "format": "int64",
                 "example": [
                   1
                 ]

--- a/test/string_types.test.js
+++ b/test/string_types.test.js
@@ -63,6 +63,31 @@ test('handling date', function(assert) {
 	assert.deepEqual(result, expected, 'date converted to date-time');
 });
 
+test('handles byte format', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'string',
+		format: 'byte'
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'string',
+		format: 'byte',
+		pattern: '^[\\w\\d+\\/=]*$'
+	};
+
+	assert.deepEqual(result, expected, 'byte converted to pattern');
+});
+
 test('retaining custom formats', function(assert) {
 	var schema
 		, result
@@ -73,7 +98,7 @@ test('retaining custom formats', function(assert) {
 
 	schema = {
 		type: 'string',
-		format: 'email'
+		format: 'custom_email'
 	};
 
 	result = convert(schema);
@@ -81,8 +106,56 @@ test('retaining custom formats', function(assert) {
 	expected = {
 		$schema: 'http://json-schema.org/draft-04/schema#',
 		type: 'string',
-		format: 'email'
+		format: 'custom_email'
 	};
 
-	assert.deepEqual(result, expected, 'email retained');
+	assert.deepEqual(result, expected, 'custom format retained');
+});
+
+test('retain password format', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'string',
+		format: 'password'
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'string',
+		format: 'password'
+	};
+
+	assert.deepEqual(result, expected, 'password format retained');
+});
+
+test('retain binary format', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'string',
+		format: 'binary'
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'string',
+		format: 'binary'
+	};
+
+	assert.deepEqual(result, expected, 'binary format retained');
 });

--- a/test/unsupported_properties.test.js
+++ b/test/unsupported_properties.test.js
@@ -110,7 +110,6 @@ test('remove writeOnly by default', function(assert) {
 		properties: {
 			test: {
 				type: 'string',
-				format: 'password',
 				writeOnly: true
 			}
 		}
@@ -123,8 +122,7 @@ test('remove writeOnly by default', function(assert) {
 		type: 'object',
 		properties: {
 			test: {
-				type: 'string',
-				format: 'password'
+				type: 'string'
 			}
 		}
 	};
@@ -301,4 +299,3 @@ test('retaining fields', function(assert) {
 
 	assert.deepEqual(result, expected, 'example and writeOnly removed');
 });
-


### PR DESCRIPTION
This PR aims at converting the [formats defined only by OpenAPI](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#data-types) but not in JSON schema v4, into something that is valid JSON schema v4.

All JSON schema v4 formats are left as is. Custom formats are also left as is. However the following OpenAPI-only formats are converted by adding extra keywords:
  - `int32`, `int64`, `float`, `double`: add related `minimum` and `maximum` keywords
  - `byte`: add `pattern` keyword to match base64. We are using standard base64, not base64url, as this is [what is intended](https://github.com/OAI/OpenAPI-Specification/issues/845#issuecomment-378139730) 
  - `password` and `binary`: left as is since they are just semantic/UI hints

I respected the following principles of JSON schema v4:
  - any `format` value is valid (i.e. custom formats are possible)
  - keywords for a specific `type` (including a specific format) might appear even if the `type` is different

I added unit tests.

I also removed the `format` keyword from non-format related unit tests, as this makes tests inter-dependent. Indeed when working on this feature, some unit tests were failing even though they were related to another feature.