### PR TITLE
Allow `type: "null"`

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function convertProperties(properties, options) {
 }
 
 function validateType(type) {
-	var validTypes = ['integer', 'number', 'string', 'boolean', 'object', 'array'];
+	var validTypes = ['integer', 'number', 'string', 'boolean', 'object', 'array', 'null'];
 
 	if (validTypes.indexOf(type) < 0 && type !== undefined) {
 		throw new InvalidTypeError('Type "' + type + '" is not a valid type');

--- a/test/invalid_types.test.js
+++ b/test/invalid_types.test.js
@@ -29,7 +29,7 @@ test('invalid types', function(assert) {
 });
 
 test('valid types', function(assert) {
-	var types = ['integer', 'number', 'string', 'boolean', 'object', 'array'];
+	var types = ['integer', 'number', 'string', 'boolean', 'object', 'array', 'null'];
 
 	assert.plan(types.length);
 


### PR DESCRIPTION
`type: "null"` is valid both in [JSON schema v4](http://json-schema.org/draft-04/schema#/properties/type) and in [OpenAPI 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v2.0/schema.json#L1015). 