### PR TITLE
Allow `type` to be an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,6 +128,10 @@ function convertProperties(properties, options) {
 }
 
 function validateType(type) {
+	if (Array.isArray(type)) {
+		return type.forEach(validateType);
+	}
+
 	var validTypes = ['integer', 'number', 'string', 'boolean', 'object', 'array'];
 
 	if (validTypes.indexOf(type) < 0 && type !== undefined) {

--- a/test/invalid_types.test.js
+++ b/test/invalid_types.test.js
@@ -50,3 +50,22 @@ test('valid types', function(assert) {
 		assert.deepEqual(result, expected, type + ' ok');
 	});
 });
+
+test('array types', function(assert) {
+	assert.plan(1);
+
+	var schema, result, expected;
+
+	schema = {
+		type: ['string', 'integer'],
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: ['string', 'integer'],
+	};
+
+	assert.deepEqual(result, expected, 'array types ok');
+});


### PR DESCRIPTION
`type` can be an array in both in [JSON schema v4](http://json-schema.org/draft-04/schema#/properties/type) and in [OpenAPI 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v2.0/schema.json#L1015). 