### PR TITLE
Schema with format overwrites minimum and maximum values

### DIFF
--- a/lib/converters/schema.js
+++ b/lib/converters/schema.js
@@ -155,26 +155,42 @@ function convertFormat(schema, options) {
 }
 
 function convertFormatInt32(schema, settings) {
-	schema.minimum = settings.MIN_INT_32;
-	schema.maximum = settings.MAX_INT_32;
+	if ((!schema.minimum && schema.minimum !== 0) || schema.minimum < settings.MIN_INT_32) {
+		schema.minimum = settings.MIN_INT_32;
+	}
+	if ((!schema.maximum && schema.maximum !== 0) || schema.maximum > settings.MAX_INT_32) {
+		schema.maximum = settings.MAX_INT_32;
+	}
 	return schema;
 }
 
 function convertFormatInt64(schema, settings) {
-	schema.minimum = settings.MIN_INT_64;
-	schema.maximum = settings.MAX_INT_64;
+	if ((!schema.minimum && schema.minimum !== 0) || schema.minimum < settings.MIN_INT_64) {
+		schema.minimum = settings.MIN_INT_64;
+	}
+	if ((!schema.maximum && schema.maximum !== 0) || schema.maximum > settings.MAX_INT_64) {
+		schema.maximum = settings.MAX_INT_64;
+	}
 	return schema;
 }
 
 function convertFormatFloat(schema, settings) {
-	schema.minimum = settings.MIN_FLOAT;
-	schema.maximum = settings.MAX_FLOAT;
+	if ((!schema.minimum && schema.minimum !== 0) || schema.minimum < settings.MIN_FLOAT) {
+		schema.minimum = settings.MIN_FLOAT;
+	}
+	if ((!schema.maximum && schema.maximum !== 0) || schema.maximum > settings.MAX_FLOAT) {
+		schema.maximum = settings.MAX_FLOAT;
+	}
 	return schema;
 }
 
 function convertFormatDouble(schema, settings) {
-	schema.minimum = settings.MIN_DOUBLE;
-	schema.maximum = settings.MAX_DOUBLE;
+	if ((!schema.minimum && schema.minimum !== 0) || schema.minimum < settings.MIN_DOUBLE) {
+		schema.minimum = settings.MIN_DOUBLE;
+	}
+	if ((!schema.maximum && schema.maximum !== 0) || schema.maximum > settings.MAX_DOUBLE) {
+		schema.maximum = settings.MAX_DOUBLE;
+	}
 	return schema;
 }
 

--- a/test/numeric_types.test.js
+++ b/test/numeric_types.test.js
@@ -28,6 +28,115 @@ test('handles int32 format', function(assert) {
 	assert.deepEqual(result, expected, 'int32 converted to minimum|maximum');
 });
 
+test('handles int32 format with specified minimum', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'integer',
+		format: 'int32',
+		minimum: 500,
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'integer',
+		format: 'int32',
+		minimum: 500,
+		maximum: Math.pow(2, 31) - 1
+	};
+
+	assert.deepEqual(result, expected, 'int32 converted to minimum|maximum');
+});
+
+test('handles int32 format with specified minimum that\'s too small', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'integer',
+		format: 'int32',
+		minimum: -Math.pow(2, 32),
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'integer',
+		format: 'int32',
+		minimum: 0 - Math.pow(2, 31),
+		maximum: Math.pow(2, 31) - 1
+	};
+
+	assert.deepEqual(result, expected, 'int32 converted to minimum|maximum');
+});
+
+test('handles int32 format with specified maximum', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'integer',
+		format: 'int32',
+		maximum: 500,
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'integer',
+		format: 'int32',
+		minimum: 0 - Math.pow(2, 31),
+		maximum: 500
+	};
+
+	assert.deepEqual(result, expected, 'int32 converted to minimum|maximum');
+});
+
+test('handles int32 format with specified minimum that\'s too big', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'integer',
+		format: 'int32',
+		maximum: Math.pow(2, 32),
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'integer',
+		format: 'int32',
+		minimum: 0 - Math.pow(2, 31),
+		maximum: Math.pow(2, 31) - 1
+	};
+
+	assert.deepEqual(result, expected, 'int32 converted to minimum|maximum');
+});
+
+
 test('handles int64 format', function(assert) {
 	var schema
 		, result
@@ -39,6 +148,114 @@ test('handles int64 format', function(assert) {
 	schema = {
 		type: 'integer',
 		format: 'int64'
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'integer',
+		format: 'int64',
+		minimum: 0 - Math.pow(2, 63),
+		maximum: Math.pow(2, 63) - 1
+	};
+
+	assert.deepEqual(result, expected, 'int64 converted to minimum|maximum');
+});
+
+test('handles int64 format with specified minimum', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'integer',
+		format: 'int64',
+		minimum: 500,
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'integer',
+		format: 'int64',
+		minimum: 500,
+		maximum: Math.pow(2, 63) - 1
+	};
+
+	assert.deepEqual(result, expected, 'int64 converted to minimum|maximum');
+});
+
+test('handles int64 format with specified minimum that\'s too small', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'integer',
+		format: 'int64',
+		minimum: -Math.pow(2, 64),
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'integer',
+		format: 'int64',
+		minimum: 0 - Math.pow(2, 63),
+		maximum: Math.pow(2, 63) - 1
+	};
+
+	assert.deepEqual(result, expected, 'int64 converted to minimum|maximum');
+});
+
+test('handles int64 format with specified maximum', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'integer',
+		format: 'int64',
+		maximum: 500,
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'integer',
+		format: 'int64',
+		minimum: 0 - Math.pow(2, 63),
+		maximum: 500
+	};
+
+	assert.deepEqual(result, expected, 'int64 converted to minimum|maximum');
+});
+
+test('handles int64 format with specified minimum that\'s too big', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'integer',
+		format: 'int64',
+		maximum: Math.pow(2, 64),
 	};
 
 	result = convert(schema);
@@ -80,6 +297,114 @@ test('handles float format', function(assert) {
 	assert.deepEqual(result, expected, 'float converted to minimum|maximum');
 });
 
+test('handles float format with specified minimum', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'number',
+		format: 'float',
+		minimum: 500,
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'number',
+		format: 'float',
+		minimum: 500,
+		maximum: Math.pow(2, 128) - 1
+	};
+
+	assert.deepEqual(result, expected, 'float converted to minimum|maximum');
+});
+
+test('handles float format with specified minimum that\'s too small', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'number',
+		format: 'float',
+		minimum: -Math.pow(2, 129),
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'number',
+		format: 'float',
+		minimum: 0 - Math.pow(2, 128),
+		maximum: Math.pow(2, 128) - 1
+	};
+
+	assert.deepEqual(result, expected, 'float converted to minimum|maximum');
+});
+
+test('handles float format with specified maximum', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'number',
+		format: 'float',
+		maximum: 500,
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'number',
+		format: 'float',
+		minimum: 0 - Math.pow(2, 128),
+		maximum: 500
+	};
+
+	assert.deepEqual(result, expected, 'float converted to minimum|maximum');
+});
+
+test('handles float format with specified minimum that\'s too big', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'number',
+		format: 'float',
+		maximum: Math.pow(2, 129),
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'number',
+		format: 'float',
+		minimum: 0 - Math.pow(2, 128),
+		maximum: Math.pow(2, 128) - 1
+	};
+
+	assert.deepEqual(result, expected, 'float converted to minimum|maximum');
+});
+
 test('handles double format', function(assert) {
 	var schema
 		, result
@@ -101,6 +426,60 @@ test('handles double format', function(assert) {
 		format: 'double',
 		minimum: 0 - Number.MAX_VALUE,
 		maximum: Number.MAX_VALUE
+	};
+
+	assert.deepEqual(result, expected, 'double converted to minimum|maximum');
+});
+
+test('handles double format with specified minimum', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'number',
+		format: 'double',
+		minimum: 50.5,
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'number',
+		format: 'double',
+		minimum: 50.5,
+		maximum: Number.MAX_VALUE - 1
+	};
+
+	assert.deepEqual(result, expected, 'double converted to minimum|maximum');
+});
+
+test('handles double format with specified maximum', function(assert) {
+	var schema
+		, result
+		, expected
+	;
+
+	assert.plan(1);
+
+	schema = {
+		type: 'number',
+		format: 'double',
+		maximum: 50.5,
+	};
+
+	result = convert(schema);
+
+	expected = {
+		$schema: 'http://json-schema.org/draft-04/schema#',
+		type: 'number',
+		format: 'double',
+		minimum: 0 - Number.MAX_VALUE,
+		maximum: 50.5
 	};
 
 	assert.deepEqual(result, expected, 'double converted to minimum|maximum');


### PR DESCRIPTION
Closes #32 

Will now only overwrite minimum and maximum values when:

1. The value is not set. `0` is considered set.
2. The value is outside the valid range (ex: maximum too big for int32)